### PR TITLE
Adding reloadPort as an argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,19 +26,20 @@ The motivation here was to write a close to the metal package from the ground up
 Add `servor` as a dev dependency using `npm i servor -D` or run directly from the terminal:
 
 ```
-npx servor <directory> <fallback> <port>
+npx servor <directory> <fallback> <port> <reloadPort>
 ```
 
 * `<directory>` path to serve static files from (defaults to current directory `.`)
 * `<fallback>` the file served for all non-file requests (defaults to `index.html`)
 * `<port>` what port you want to serve the files from (defaults to `8080`)
+* `<reloadPort>` what port you want the reload script to listen on (defaults to `5000`)
 
 Example usage with npm scripts in a project's `package.json` file:
 
 ```json
 {
   "scripts": {
-    "start": "npx servor www index.html 8080"
+    "start": "npx servor www index.html 8080 5000"
   }
 }
 ```

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "reload"
   ],
   "scripts": {
-    "test": "node servor test index.html 8080",
+    "test": "node servor test index.html 8080 5000",
     "start": "node servor"
   },
   "author": "Luke Jackson <lukejacksonn@gmail.com>",

--- a/servor.js
+++ b/servor.js
@@ -16,24 +16,25 @@ const mime = Object.entries(require("./types.json")).reduce(
 );
 
 // ----------------------------------
-// Template clientside reload script
-// ----------------------------------
-
-const reloadScript = `
-  <script>
-    const source = new EventSource('http://localhost:5000');
-    source.onmessage = e => location.reload(true);
-  </script>
-`;
-
-// ----------------------------------
 // Parse arguments from the command line
 // ----------------------------------
 
 const root = process.argv[2] || ".";
 const fallback = process.argv[3] || "index.html";
 const port = process.argv[4] || 8080;
+const reloadPort = process.argv[5] || 5000;
 const cwd = process.cwd();
+
+// ----------------------------------
+// Template clientside reload script
+// ----------------------------------
+
+const reloadScript = `
+  <script>
+    const source = new EventSource('http://localhost:${reloadPort}');
+    source.onmessage = e => location.reload(true);
+  </script>
+`;
 
 // ----------------------------------
 // Server utility functions
@@ -90,7 +91,7 @@ http
       sendMessage(res, "message", "reloading page")
     );
   })
-  .listen(5000);
+  .listen(parseInt(reloadPort, 10));
 
 // ----------------------------------
 // Start static file server


### PR DESCRIPTION
I sometimes have other projects that use port 5000 and wanted to make this configurable. It still defaults to `5000` and I updated the docs accordingly, ran the test and confirmed that it worked.

Let me know what you think, and thanks for this handy file server!