### PR TITLE
Add flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Servør
 
-
 > A dependency free dev server for single page app development
 
 The new and improved version of [http-server-spa](https://npmjs.com/http-server-spa). A zero dependency static file server with built in file watching, browser reloading and history api fallback defaults to support rapid single page app development.
@@ -11,15 +10,15 @@ The new and improved version of [http-server-spa](https://npmjs.com/http-server-
 
 <hr>
 
-The motivation here was to write a close to the metal package from the ground up, in a single (~120 LOC) file and employing only native node and browser APIs to do a very specific task. Inspiration was taken from more comprehensive packages like [serve](https://github.com/zeit/serve) and [budo](https://github.com/mattdesl/budo) which both do a similarly great job.
+The motivation here was to write a close to the metal package from the ground up, in a single (~150 LOC) file and employing only native node and browser APIs to do a very specific task. Inspiration was taken from more comprehensive packages like [serve](https://github.com/zeit/serve) and [budo](https://github.com/mattdesl/budo) which both do a similarly great job.
 
 ## Features
 
-* 🗂 Serve static content like scripts, styles, images from a directory
-* 🖥 Reroute all non-file requests like `/` or `/admin` to a single file
-* ♻️ Reload the browser when project files get added, removed or modified
-* ⏱ Install using `npx` and be running in the browser in ~1 second
-* 📚 Readable source code that encourages learning and contribution
+- 🗂 Serve static content like scripts, styles, images from a directory
+- 🖥 Reroute all non-file requests like `/` or `/admin` to a single file
+- ♻️ Reload the browser when project files get added, removed or modified
+- ⏱ Install using `npx` and be running in the browser in ~1 second
+- 📚 Readable source code that encourages learning and contribution
 
 ## Usage
 
@@ -29,19 +28,15 @@ Add `servor` as a dev dependency using `npm i servor -D` or run directly from th
 npx servor <directory> <fallback> <port> <reloadPort> <browser>
 ```
 
-* `<directory>` path to serve static files from (defaults to current directory `.`)
-* `<fallback>` the file served for all non-file requests (defaults to `index.html`)
-* `<port>` what port you want to serve the files from (defaults to `8080`)
-* `<reloadPort>` what port you want the reload script to listen on (defaults to `5000`)
-* `<browser>` wether to open the browser after starting the server (accepts `no` defaults to `yes`)
+- `<directory>` path to serve static files from (defaults to current directory `.`)
+- `<fallback>` the file served for all non-file requests (defaults to `index.html`)
+- `<port>` what port you want to serve the files from (defaults to `8080`)
+- `<reloadPort>` what port you want the reload script to listen on (defaults to `5000`)
 
-It is possible to pass in all the options above as named as well as positional arguments for example:
+There are also optional flags you can pass as arguments:
 
-```
-$ npx servor www index.html --port 1337 --browser no
-```
-
-> **NOTE:** Named arguments will always take presedence over positional arguments.
+- `--no-browser` prevents the browser from opening when the server starts
+- `--no-reload` prevents the browser from reloading when files change
 
 Example usage with npm scripts in a project's `package.json` file:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "servor",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "description": "A dependency free dev server for single page app development",
   "repository": "lukejacksonn/servor",
   "main": "./servor.js",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "reload"
   ],
   "scripts": {
-    "test": "node servor test index.html 8080 5000 --browser no",
+    "test": "node servor test index.html 8080 5000",
     "start": "node servor"
   },
   "author": "Luke Jackson <lukejacksonn@gmail.com>",

--- a/servor.js
+++ b/servor.js
@@ -1,49 +1,35 @@
 #!/usr/bin/env node
 
-const fs = require("fs");
-const url = require("url");
-const path = require("path");
-const http = require("http");
+const fs = require('fs')
+const url = require('url')
+const path = require('path')
+const http = require('http')
 
 // ----------------------------------
 // Generate map of all known mimetypes
 // ----------------------------------
 
-const mime = Object.entries(require("./types.json")).reduce(
+const mime = Object.entries(require('./types.json')).reduce(
   (all, [type, exts]) =>
     Object.assign(all, ...exts.map(ext => ({ [ext]: type }))),
   {}
-);
+)
 
 // ----------------------------------
 // Parse arguments from the command line
 // ----------------------------------
 
-const defaults = {
-  root: ".",
-  fallback: "index.html",
-  port: 8080,
-  reloadPort: 5000,
-  browser: 'yes'
-};
+const args = process.argv.slice(2).filter(x => !~x.indexOf('--'))
 
-const input = process.argv.slice(2).join(" ");
-// Extract positional arguments
-const args = input.replace(/--([^\s]*)\s[^\s]*(\s)?/g, "").trim().split(" ");
-// Extract named arguments
-const named = (input.match(/--([^\s]*)\s[^\s]*/g, "") || []).reduce((a, b) => {
-  const [key, value] = b.split(" ");
-  return Object.assign(a, { [key.replace("--", "")]: value });
-}, {});
+const root = args[0] || '.'
+const fallback = args[1] || 'index.html'
+const port = args[2] || 8080
+const reloadPort = args[3] || 5000
 
-const options = Object.entries(defaults).reduce(
-  (opts, [key, val], i) =>
-    Object.assign(opts, { [key]: named[key] || args[i] || val }),
-  {}
-);
+const browser = !~process.argv.indexOf('--no-browser')
+const reload = !~process.argv.indexOf('--no-reload')
 
-const { root, fallback, port, reloadPort, browser } = options;
-const cwd = process.cwd();
+const cwd = process.cwd()
 
 // ----------------------------------
 // Template clientside reload script
@@ -54,64 +40,65 @@ const reloadScript = `
     const source = new EventSource('http://localhost:${reloadPort}');
     source.onmessage = e => location.reload(true);
   </script>
-`;
+`
 
 // ----------------------------------
 // Server utility functions
 // ----------------------------------
 
 const sendError = (res, resource, status) => {
-  res.writeHead(status);
-  res.end();
-  console.log(" \x1b[41m", status, "\x1b[0m", `${resource}`);
-};
+  res.writeHead(status)
+  res.end()
+  console.log(' \x1b[41m', status, '\x1b[0m', `${resource}`)
+}
 
 const sendFile = (res, resource, status, file, ext) => {
   res.writeHead(status, {
-    "Content-Type": mime[ext] || "application/octet-stream",
-    "Access-Control-Allow-Origin": "*"
-  });
-  res.write(file, "binary");
-  res.end();
-  console.log(" \x1b[42m", status, "\x1b[0m", `${resource}`);
-};
+    'Content-Type': mime[ext] || 'application/octet-stream',
+    'Access-Control-Allow-Origin': '*',
+  })
+  res.write(file, 'binary')
+  res.end()
+  console.log(' \x1b[42m', status, '\x1b[0m', `${resource}`)
+}
 
 const sendMessage = (res, channel, data) => {
-  res.write(`event: ${channel}\nid: 0\ndata: ${data}\n`);
-  res.write("\n\n");
-};
+  res.write(`event: ${channel}\nid: 0\ndata: ${data}\n`)
+  res.write('\n\n')
+}
 
 const isRouteRequest = uri =>
   uri
-    .split("/")
+    .split('/')
     .pop()
-    .indexOf(".") === -1
+    .indexOf('.') === -1
     ? true
-    : false;
+    : false
 
 // ----------------------------------
 // Start file watching server
 // ----------------------------------
 
-http
-  .createServer((request, res) => {
-    // Open the event stream for live reload
-    res.writeHead(200, {
-      Connection: "keep-alive",
-      "Content-Type": "text/event-stream",
-      "Cache-Control": "no-cache",
-      "Access-Control-Allow-Origin": "*"
-    });
-    // Send an initial ack event to stop request pending
-    sendMessage(res, "connected", "awaiting change");
-    // Send a ping event every minute to prevent console errors
-    setInterval(sendMessage, 60000, res, "ping", "still waiting");
-    // Watch the target directory for changes and trigger reload
-    fs.watch(path.join(cwd, root), { recursive: true }, () =>
-      sendMessage(res, "message", "reloading page")
-    );
-  })
-  .listen(parseInt(reloadPort, 10));
+reload &&
+  http
+    .createServer((request, res) => {
+      // Open the event stream for live reload
+      res.writeHead(200, {
+        Connection: 'keep-alive',
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        'Access-Control-Allow-Origin': '*',
+      })
+      // Send an initial ack event to stop request pending
+      sendMessage(res, 'connected', 'awaiting change')
+      // Send a ping event every minute to prevent console errors
+      setInterval(sendMessage, 60000, res, 'ping', 'still waiting')
+      // Watch the target directory for changes and trigger reload
+      fs.watch(path.join(cwd, root), { recursive: true }, () =>
+        sendMessage(res, 'message', 'reloading page')
+      )
+    })
+    .listen(parseInt(reloadPort, 10))
 
 // ----------------------------------
 // Start static file server
@@ -119,44 +106,44 @@ http
 
 http
   .createServer((req, res) => {
-    const pathname = url.parse(req.url).pathname;
-    const isRoute = isRouteRequest(pathname);
-    const status = isRoute && pathname !== "/" ? 301 : 200;
-    const resource = isRoute ? `/${fallback}` : decodeURI(pathname);
-    const uri = path.join(cwd, root, resource);
-    const ext = uri.replace(/^.*[\.\/\\]/, "").toLowerCase();
-    isRoute && console.log("\n \x1b[44m", "RELOADING", "\x1b[0m\n");
+    const pathname = url.parse(req.url).pathname
+    const isRoute = isRouteRequest(pathname)
+    const status = isRoute && pathname !== '/' ? 301 : 200
+    const resource = isRoute ? `/${fallback}` : decodeURI(pathname)
+    const uri = path.join(cwd, root, resource)
+    const ext = uri.replace(/^.*[\.\/\\]/, '').toLowerCase()
+    isRoute && console.log('\n \x1b[44m', 'RELOADING', '\x1b[0m\n')
     // Check if files exists at the location
     fs.stat(uri, (err, stat) => {
-      if (err) return sendError(res, resource, 404);
+      if (err) return sendError(res, resource, 404)
       // Respond with the contents of the file
-      fs.readFile(uri, "binary", (err, file) => {
-        if (err) return sendError(res, resource, 500);
-        if (isRoute) file += reloadScript;
-        sendFile(res, resource, status, file, ext);
-      });
-    });
+      fs.readFile(uri, 'binary', (err, file) => {
+        if (err) return sendError(res, resource, 500)
+        if (isRoute && reload) file += reloadScript
+        sendFile(res, resource, status, file, ext)
+      })
+    })
   })
-  .listen(parseInt(port, 10));
+  .listen(parseInt(port, 10))
 
 // ----------------------------------
 // Log startup details to terminal
 // ----------------------------------
 
-console.log(`\n 🗂  Serving files from ./${root} on http://localhost:${port}`);
-console.log(` 🖥  Using ${fallback} as the fallback for route requests`);
-console.log(` ♻️  Reloading the browser when files under ./${root} change`);
+console.log(`\n 🗂  Serving files from ./${root} on http://localhost:${port}`)
+console.log(` 🖥  Using ${fallback} as the fallback for route requests`)
+console.log(` ♻️  Reloading the browser when files under ./${root} change`)
 
 // ----------------------------------
 // Open the page in the default browser
 // ----------------------------------
 
-const page = `http://localhost:${port}`;
+const page = `http://localhost:${port}`
 const open =
-  process.platform == "darwin"
-    ? "open"
-    : process.platform == "win32"
-    ? "start"
-    : "xdg-open";
+  process.platform == 'darwin'
+    ? 'open'
+    : process.platform == 'win32'
+    ? 'start'
+    : 'xdg-open'
 
-browser !== 'no' && require("child_process").exec(open + " " + page);
+browser && require('child_process').exec(open + ' ' + page)

--- a/test/index.html
+++ b/test/index.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta charset="utf-8">
+    <meta charset="utf-8" />
     <title>Web Application</title>
-    <link rel="stylesheet" href="/assets/index.css" charset="utf-8">
+    <link rel="stylesheet" href="/assets/index.css" />
     <script defer src="/assets/index.js"></script>
   </head>
   <body>


### PR DESCRIPTION
So I messed up 🤦‍♂️ in trying to solve a few issue at once and too focussed on reviewing PRs I made what I think no was the wrong decision.

The PRs #14 and #15 were trying to solve two problems:

- The first was https://github.com/lukejacksonn/servor/issues/11 which was to implement named arguments so that if you wanted to modify the nth positional arg only then you could do so without specifying the nth - n arguments.

- The second was #17 which suggested a flag that would prevent the browser from opening when the browser starts.

The implementations were very similar and named arguments seemed like the answer to both these issue but in retrospect I think it has taken away from the simplicity of both the API and the codebase.

So I am instead proposing going back to positional arguments only but adding the flags:

- `--no-browser` prevents the browser from opening when the server starts
- `--no-reload` prevents the browser from reloading when files change

I know this doesn't help with #11 but I justify not doing this with _keeping it simple_ with just positional arguments; typing out the args if you don't want the defaults is explicit and not too verbose.

Sorry for the quick mind change and any confusion this might have caused!