### PR TITLE
Use Array.prototype.startsWith and Array.prototype.includes instead o…

### DIFF
--- a/servor.js
+++ b/servor.js
@@ -19,15 +19,15 @@ const mime = Object.entries(require('./types.json')).reduce(
 // Parse arguments from the command line
 // ----------------------------------
 
-const args = process.argv.slice(2).filter(x => !~x.indexOf('--'))
+const args = process.argv.slice(2).filter(x => !x.startsWith('--'))
 
 const root = args[0] || '.'
 const fallback = args[1] || 'index.html'
 const port = args[2] || 8080
 const reloadPort = args[3] || 5000
 
-const browser = !~process.argv.indexOf('--no-browser')
-const reload = !~process.argv.indexOf('--no-reload')
+const browser = !process.argv.includes('--no-browser')
+const reload = !process.argv.includes('--no-reload')
 
 const cwd = process.cwd()
 


### PR DESCRIPTION
…f ~Array.prototype.indexOf

I thought using `startsWith` and `includes` made the code more understandable.

I also noticed that the current approach to get the `args` array would omit arguments that contained `--` anywhere in the string such as `"-a--b"`, using `startsWith` `"-a--b"` would be included in the `args` array.