### PR TITLE
support to ignore folder and files to prevent reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,14 @@ Add `servor` as a dev dependency using `npm i servor -D` or run directly from th
 npx servor <directory> <fallback> <port> <reloadPort>
 ```
 
-- `<directory>` path to serve static files from (defaults to current directory `.`)
+- `<directory>` path to serve static files from (defaults to current directory `.`), you can declare using the wildcard `!`, to indicate which folders or files to ignore for the reload, `public!img,ignore.js`
 - `<fallback>` the file served for all non-file requests (defaults to `index.html`)
 - `<port>` what port you want to serve the files from (defaults to `8080`)
 - `<reloadPort>` what port you want the reload script to listen on (defaults to `5000`)
 
 There are also optional flags you can pass as arguments:
 
-- `--no-browser` prevents the browser from opening when the server starts
+- `--no-browser` prevents the browgitser from opening when the server starts
 - `--no-reload` prevents the browser from reloading when files change
 
 Example usage with npm scripts in a project's `package.json` file:

--- a/servor.js
+++ b/servor.js
@@ -23,13 +23,13 @@ const args = process.argv.slice(2).filter(x => !~x.indexOf('--'))
 
 const cwd = process.cwd();
 const slash = `(?:\\/|\\\\)`;
-const [public,root,ignore] = (args[0] || '.').match(/([^\!]*)(?:\!(.*)){0,}/)
+const [root,ignore=""] = (args[0] || '.').split("!")
 /**
  * create expressions to ignore changes in a folder or file
  * @example 
  * servor test!assets,index.html
  */
-const ignores = (ignore ? ignore.replace(/\//g,slash+"{1,2}").split(/ *, */) : []).map(folder=>{
+const ignores =  ignore.replace(/\//g,slash+"{1,2}").split(/ *, */).map(folder=>{
   if(/\..+/.test(folder)){
     folder = folder.replace(/\./g,"\\.")+"$";
   }else{


### PR DESCRIPTION
Hi!👋, I have decided to use Servor as a development server when using [Atomico](https://github.com/atomicojs/core), a small library for the use of web-components, to create the bundle using Rollup, but this one that generates files at different times, part of these files are not required for Preview the index.html. Servor is currently sensitive to any change, with the added code, allows you to define which folders or files should be ignored by the watch

for this you can use the wildcard `!`, example:

## case 1

```bash
servor public!README.md
```
the previous allows to observe by Servor the folder `public`, but the watch will ignore the generated changes to` README.md`

## case 2

```bash
servor !src
```
the previous allows you to observe the `root` directory, but the watch will ignore the changes made within the `src` folder

## case 3

```bash
servor public!folder,data.json
```
this allows you to observe the changes of the `public` directory, but ignore those generated in `folder` or those generated on `data.json`

The change does not break the current code, just add this option as an additional on <directory>