### PR TITLE
Use HTTP2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+--install.pure-lockfile true

--- a/package.json
+++ b/package.json
@@ -19,5 +19,8 @@
     "start": "node servor"
   },
   "author": "Luke Jackson <lukejacksonn@gmail.com>",
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "selfsigned": "^1.10.4"
+  }
 }


### PR DESCRIPTION
Hi, this is something we talked about before and I just had a go at trying to do it.

Since HTTP2 requires an encrypted connection for browsers we need to use certs. I thought it would be a lot easier if we just generate them on startup using the `selfsigned` module to save people having to generate them. Once this was done I realised it's probably easier to fully convert to using HTTP2 and drop HTTP support. Realistically users will be using HTTP2 in production so why not just use it in development too? It saves having more CLI arguments as to whether to use HTTP2 or not 🤷‍♂ 

The reload server is still using HTTP1 because I was getting an error I just couldn't figure out - https://github.com/nodejs/help/issues/1779. Although it's now HTTPS to avoid mixed response errors in browsers.

- [x] Add `.gitignore` to ignore `node_modules`
- [x] Use `.yarnrc` to stop a yarn.lock` being made
- [x] Add `selfsigned` to generate certs on startup for `localhost`
  - [x] Seems to be really fast so no need to cache them on filesystem like [`webpack-dev-server`](https://github.com/webpack/webpack-dev-server/blob/master/lib/utils/getCertificate.js) does
- [x] Convert file server to be HTTP2 only and reload server to be HTTPS

Couple of other things to consider:
* HTTP2 is in Node 8.4.0 so might be worth sticking `engines` in the `package.json` to state that is needed too.
* Should we allow a `--host` argument so people can choose something other than `localhost`?

Anyway, let me know what you think since these are quite big changes. 