### PR TITLE
List local network IPs for easy discovery

### DIFF
--- a/servor.js
+++ b/servor.js
@@ -129,15 +129,11 @@ http
 // ----------------------------------
 // Get available IP addresses
 // ----------------------------------
-const ips = []
 const interfaces = require('os').networkInterfaces()
-for (const interface in interfaces) {
-  interfaces[interface].forEach(ip => {
-    if (ip.family === 'IPv4' && ip.internal === false) {
-      ips.push(ip.address)
-    }
-  })
-}
+const ips = Object.values(interfaces)
+  .flat()
+  .filter(ip => ip.family === 'IPv4' && ip.internal === false)
+  .map(ip => `http://${ip.address}:${port}`)
 
 // ----------------------------------
 // Log startup details to terminal
@@ -147,7 +143,7 @@ console.log(`\n 🗂  Serving files from ./${root} on http://localhost:${port}`)
 console.log(` 🖥  Using ${fallback} as the fallback for route requests`)
 console.log(` ♻️  Reloading the browser when files under ./${root} change`)
 if (ips.length > 0) {
-  console.log(` 📡  Available on your network on http://${ips.join(`:${port}, http://`)}:${port}`)
+  console.log(` 📡  Available on your network on ${ips.join(', ')}`)
 }
 
 // ----------------------------------

--- a/servor.js
+++ b/servor.js
@@ -127,12 +127,28 @@ http
   .listen(parseInt(port, 10))
 
 // ----------------------------------
+// Get available IP addresses
+// ----------------------------------
+const ips = []
+const interfaces = require('os').networkInterfaces()
+for (const interface in interfaces) {
+  interfaces[interface].forEach(ip => {
+    if (ip.family === 'IPv4' && ip.internal === false) {
+      ips.push(ip.address)
+    }
+  })
+}
+
+// ----------------------------------
 // Log startup details to terminal
 // ----------------------------------
 
 console.log(`\n 🗂  Serving files from ./${root} on http://localhost:${port}`)
 console.log(` 🖥  Using ${fallback} as the fallback for route requests`)
 console.log(` ♻️  Reloading the browser when files under ./${root} change`)
+if (ips.length > 0) {
+  console.log(` 📡  Available on your network on http://${ips.join(`:${port}, http://`)}:${port}`)
+}
 
 // ----------------------------------
 // Open the page in the default browser


### PR DESCRIPTION
Fixes #18.

This finds the same IP addresses as the bash script from https://github.com/lukejacksonn/servor/issues/18#issuecomment-486180164 using node’s build-in (and cross-platform compatible) methods. It also supports listing multiple IPs when this is needed, e.g. when connected to both WiFi and Ethernet.

<img width="745" alt="Screenshot: showing output of `npm run test` in the terminal" src="https://user-images.githubusercontent.com/490579/62879842-4b3cd780-bd2c-11e9-8444-6d9c001c155c.png">

