### PR TITLE
DO NOT MERGE: provide api interface to servor

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+
+const servor = require('./servor');
+
+// ----------------------------------
+// Parse arguments from the command line
+// ----------------------------------
+
+const root = process.argv[2] || ".";
+const fallback = process.argv[3] || "index.html";
+const port = process.argv[4] || 8080;
+const reloadPort = process.argv[5] || 5000;
+const cwd = process.cwd();
+
+servor(root, fallback, port, reloadPort, cwd);

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "repository": "lukejacksonn/servor",
   "main": "./servor.js",
   "bin": {
-    "servor": "./servor.js"
+    "servor": "./cli.js"
   },
   "keywords": [
     "development",
@@ -15,8 +15,8 @@
     "reload"
   ],
   "scripts": {
-    "test": "node servor test index.html 8080 5000",
-    "start": "node servor"
+    "test": "node cli test index.html 8080 5000",
+    "start": "node cli"
   },
   "author": "Luke Jackson <lukejacksonn@gmail.com>",
   "license": "MIT"

--- a/servor.js
+++ b/servor.js
@@ -1,9 +1,9 @@
-#!/usr/bin/env node
-
 const fs = require("fs");
 const url = require("url");
 const path = require("path");
 const http = require("http");
+
+module.exports = function(root, fallback, port, reloadPort, cwd){
 
 // ----------------------------------
 // Generate map of all known mimetypes
@@ -14,16 +14,6 @@ const mime = Object.entries(require("./types.json")).reduce(
     Object.assign(all, ...exts.map(ext => ({ [ext]: type }))),
   {}
 );
-
-// ----------------------------------
-// Parse arguments from the command line
-// ----------------------------------
-
-const root = process.argv[2] || ".";
-const fallback = process.argv[3] || "index.html";
-const port = process.argv[4] || 8080;
-const reloadPort = process.argv[5] || 5000;
-const cwd = process.cwd();
 
 // ----------------------------------
 // Template clientside reload script
@@ -140,3 +130,4 @@ const open =
       : "xdg-open";
 
 require("child_process").exec(open + " " + page);
+}


### PR DESCRIPTION
Hi @lukejacksonn 

This PR presents a possible approach for exposing javascript API for `servor`. If you are willing to consider such change, it will enable usage of `servor` outside the command line context.

My motivation here is to use the exposed javascript API to build a rollup plugin which utilizes `servor` for serve and livereload (a.k.a alternative to [serve](https://www.npmjs.com/package/rollup-plugin-serve) and [livereload](https://www.npmjs.com/package/rollup-plugin-livereload) plugins)

Ultimately I want to use it in a zero dependency, zero config packager I am working on https://github.com/osdevisnot/klap

This PR is marked as 'DO NOT MERGE' as I realized you might be using v2 branch for latest updates.