### PR TITLE
Try default port before picking a random free port

### DIFF
--- a/servor.js
+++ b/servor.js
@@ -45,9 +45,9 @@ module.exports = async ({
   credentials
 } = {}) => {
   try {
-    port = await fport(port || 8080);
+    port = await fport(port || process.env.PORT || 8080);
   } catch {
-    if (port) {
+    if (port || process.env.PORT) {
       console.log('[ERR] The port you have specified is already in use!');
       process.exit();
     }


### PR DESCRIPTION
As discussed in #34 having the server starting on a completely random port (if no port is explicitly provided) can be confusing for non power users.

This PR address the issue by changing this behaviour. The port selection behaviour is now as follows:

- If a port is provided in the positional arguments (for example `servor . index.html 1337`) or as an environment variable (for example `PORT=1337 servor`) then try start the server on the specified port. If this fails then `process.exit` and log that the specified port is already in use.
- If no port is provided in the positional arguments then try start the server on port `8080`. If this fails then start the server on a random available port.

This behaviour aligns better with other local file server modules (which usually pick a default port to run on, albeit usually failing if they cannot do so) and so hopefully helps eliminate some potential for confusion.