### PR TITLE
add enhancements for file watcher (fs.watch)

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
     "test:secure": "yarn test --secure"
   },
   "author": "Luke Jackson <lukejacksonn@gmail.com>",
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "node-watch": "^0.6.3"
+  }
 }

--- a/servor.js
+++ b/servor.js
@@ -6,6 +6,7 @@ const https = require('https');
 const os = require('os');
 const net = require('net');
 const cwd = process.cwd();
+const watch = require('node-watch')
 
 const fport = (p = 0) =>
   new Promise((resolve, reject) => {
@@ -122,7 +123,7 @@ module.exports = async ({
   // Notify livereload clients on file change
 
   reload &&
-    fs.watch(root, { recursive: true }, () => {
+    watch(root, { recursive: true }, () => {
       while (clients.length > 0)
         sendMessage(clients.pop(), 'message', 'reload');
     });


### PR DESCRIPTION
- fixes #36
- fs.watch recursive option is only supported on macOS and Windows (see https://nodejs.org/docs/latest/api/fs.html#fs_caveats)
- add node-watch as a thin wrapper for fs.watch
- node-watch author claims it's much faster and more memory efficient than fs.watch