### PR TITLE
Inject livereload code at EOF

### DIFF
--- a/servor.js
+++ b/servor.js
@@ -124,7 +124,7 @@ module.exports = async ({
         fs.readFile(uri, 'binary', (err, file) => {
           if (err) return sendError(res, resource, 500);
           if (isRoute && inject) file = inject + file;
-          if (isRoute && reload) file = livereload + file;
+          if (isRoute && reload) file = file + livereload;
           sendFile(res, resource, status, file, ext);
         });
       });


### PR DESCRIPTION
# Summary

This change moves the `livereload` code to the end of the file instead of the start so that a doctype declaration can preserve its position at the start of the file.

# Motivation

One of the libraries I'm using ([react-beautiful-dnd](https://github.com/atlassian/react-beautiful-dnd)) logs warnings in the console if it can't detect an HTML5 doctype. It's not a huge problem because it's only an issue in development, but the workaround to suppress the warning is pretty clumsy.

# Notes 

- I'm not aware of any disadvantages to loading it at the end of the file instead of the start.
- The `inject` code might also be worth moving, but that could introduce a breaking change depending on how people have used it. (Might be worthwhile having `prepend` and `append` options instead of a generic `inject` option?)