### PR TITLE
Use gzip for certain file types

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > A dependency free dev server for modern web application development
 
-The new and enhanced version of [http-server-spa](https://npmjs.com/http-server-spa). A very compact but capable static file server with https, live reloading and other useful features to support web app development on localhost and over a local network.
+The new and enhanced version of [http-server-spa](https://npmjs.com/http-server-spa). A very compact but capable static file server with https, live reloading, gzip and other useful features to support web app development on localhost and over a local network.
 
 Servør can be invoked via the command line or programmatically using the node API.
 
@@ -15,9 +15,10 @@ Servør can be invoked via the command line or programmatically using the node A
 The motivation here was to write a package from the ground up with no dependencies; using only native node and browser APIs to do a specific task with minimal code.
 
 - 🗂 Serves static content like scripts, styles, images from a given directory
-- 🖥 Redirects all path requests to a single file for frontend routing
+- 🗜 Uses gzip on common filetypes like html, css and js to give a production feel
 - ♻️ Reloads the browser when project files get added, removed or modified
 - 🔐 Supports https with self signed certificates added to the systems trusted store
+- 🖥 Redirects all path requests to a single file for frontend routing
 - 🔎 Discovers freely available ports to serve on if no port is specified
 
 ## CLI Usage

--- a/cli.js
+++ b/cli.js
@@ -28,7 +28,7 @@ const open =
 
   if (~process.argv.indexOf('--secure')) {
     admin && certify();
-    process.setuid(501);
+    admin && process.platform === 'darwin' && process.setuid(501);
     try {
       credentials = readCredentials();
     } catch (e) {

--- a/cli.js
+++ b/cli.js
@@ -4,12 +4,12 @@ const servor = require('./servor.js');
 
 const readCredentials = () => ({
   cert: fs.readFileSync(__dirname + '/servor.crt'),
-  key: fs.readFileSync(__dirname + '/servor.key')
+  key: fs.readFileSync(__dirname + '/servor.key'),
 });
 
 const certify = () =>
   require('child_process').execSync(__dirname + '/certify.sh', {
-    cwd: __dirname
+    cwd: __dirname,
   });
 
 const open =
@@ -20,7 +20,7 @@ const open =
     : 'xdg-open';
 
 (async () => {
-  const args = process.argv.slice(2).filter(x => !~x.indexOf('--'));
+  const args = process.argv.slice(2).filter((x) => !~x.indexOf('--'));
   const admin = process.getuid && process.getuid() === 0;
   let credentials;
 
@@ -50,8 +50,8 @@ const open =
     root: args[0],
     fallback: args[1],
     port: args[2],
-    reload: ~process.argv.indexOf('--reload'),
-    credentials
+    reload: !!~process.argv.indexOf('--reload'),
+    credentials,
   });
 
   // Output server details to the console
@@ -60,11 +60,11 @@ const open =
     console.log(`
   🗂  Serving:\t${root}\n
   🏡 Local:\t${url}
-  ${ips.map(ip => `📡 Network:\t${protocol}://${ip}:${port}`).join('\n  ')}
+  ${ips.map((ip) => `📡 Network:\t${protocol}://${ip}:${port}`).join('\n  ')}
   `);
 
   // Browser the server index
 
-  ~process.argv.indexOf('--browse') &&
+  !!~process.argv.indexOf('--browse') &&
     require('child_process').execSync(`${open} ${url}`);
 })();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "servor",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "A dependency free dev server for single page app development",
   "repository": "lukejacksonn/servor",
   "main": "./servor.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "servor",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "A dependency free dev server for single page app development",
   "repository": "lukejacksonn/servor",
   "main": "./servor.js",

--- a/servor.js
+++ b/servor.js
@@ -12,7 +12,9 @@ const watch =
     ? (path, cb) => {
         if (fs.statSync(path).isDirectory()) {
           fs.watch(path, cb);
-          fs.readdirSync(path).forEach(entry => watch(`${path}/${entry}`, cb));
+          fs.readdirSync(path).forEach((entry) =>
+            watch(`${path}/${entry}`, cb)
+          );
         }
       }
     : (path, cb) => fs.watch(path, { recursive: true }, cb);
@@ -29,12 +31,12 @@ const fport = (p = 0) =>
 
 const ips = Object.values(os.networkInterfaces())
   .reduce((every, i) => [...every, ...i], [])
-  .filter(i => i.family === 'IPv4' && i.internal === false)
-  .map(i => i.address);
+  .filter((i) => i.family === 'IPv4' && i.internal === false)
+  .map((i) => i.address);
 
 const mimes = Object.entries(require('./types.json')).reduce(
   (all, [type, exts]) =>
-    Object.assign(all, ...exts.map(ext => ({ [ext]: type }))),
+    Object.assign(all, ...exts.map((ext) => ({ [ext]: type }))),
   {}
 );
 
@@ -54,11 +56,11 @@ module.exports = async ({
   port,
   reload = true,
   inject,
-  credentials
+  credentials,
 } = {}) => {
   try {
     port = await fport(port || process.env.PORT || 8080);
-  } catch(e) {
+  } catch (e) {
     if (port || process.env.PORT) {
       console.log('[ERR] The port you have specified is already in use!');
       process.exit();
@@ -69,8 +71,8 @@ module.exports = async ({
   const clients = [];
   const protocol = credentials ? 'https' : 'http';
   const server = credentials
-    ? cb => https.createServer(credentials, cb)
-    : cb => http.createServer(cb);
+    ? (cb) => https.createServer(credentials, cb)
+    : (cb) => http.createServer(cb);
 
   // Server utility functions
 
@@ -82,7 +84,7 @@ module.exports = async ({
   const sendFile = (res, resource, status, file, ext) => {
     res.writeHead(status, {
       'Content-Type': mimes[ext] || 'application/octet-stream',
-      'Access-Control-Allow-Origin': '*'
+      'Access-Control-Allow-Origin': '*',
     });
     res.write(file, 'binary');
     res.end();
@@ -93,11 +95,7 @@ module.exports = async ({
     res.write('\n\n');
   };
 
-  const isRouteRequest = pathname =>
-    !~pathname
-      .split('/')
-      .pop()
-      .indexOf('.');
+  const isRouteRequest = (pathname) => !~pathname.split('/').pop().indexOf('.');
 
   // Start the server on the desired port
 
@@ -108,7 +106,7 @@ module.exports = async ({
         Connection: 'keep-alive',
         'Content-Type': 'text/event-stream',
         'Cache-Control': 'no-cache',
-        'Access-Control-Allow-Origin': '*'
+        'Access-Control-Allow-Origin': '*',
       });
       sendMessage(res, 'connected', 'ready');
       setInterval(sendMessage, 60000, res, 'ping', 'waiting');
@@ -149,6 +147,6 @@ module.exports = async ({
     root,
     protocol,
     port,
-    ips
+    ips,
   };
 };

--- a/servor.js
+++ b/servor.js
@@ -121,7 +121,7 @@ module.exports = async ({
         if (err) return sendError(res, resource, 404);
         fs.readFile(uri, 'binary', (err, file) => {
           if (err) return sendError(res, resource, 500);
-          if (isRoute && inject) file = inject + file;
+          if (isRoute && inject) file = file + inject;
           if (isRoute && reload) file = file + livereload;
           sendFile(res, resource, status, file, ext);
         });

--- a/servor.js
+++ b/servor.js
@@ -5,6 +5,7 @@ const http = require('http');
 const https = require('https');
 const os = require('os');
 const net = require('net');
+const zlib = require('zlib');
 const cwd = process.cwd();
 
 const watch =
@@ -88,12 +89,18 @@ module.exports = async ({
     res.end();
   };
 
-  const sendFile = (res, status, file, ext) => {
+  const sendFile = (res, status, file, ext, encoding = 'binary') => {
+    if (['js', 'css', 'html', 'json', 'xml', 'svg'].includes(ext)) {
+      res.removeHeader('Content-Length');
+      res.setHeader('Content-Encoding', 'gzip');
+      file = zlib.gzipSync(Buffer.from(file, 'binary').toString('utf8'));
+      encoding = 'utf8';
+    }
     res.writeHead(status, {
       'Content-Type': mimes[ext] || 'application/octet-stream',
       'Access-Control-Allow-Origin': '*',
     });
-    res.write(file, 'binary');
+    res.write(file, encoding);
     res.end();
   };
 


### PR DESCRIPTION
Now enabled for files with the extension `['js', 'css', 'html', 'json', 'xml', 'svg']` which is probably all that needs compressing at least for a start.

Also fixes #43 and #46 and runs through latest prettier (hence the diff).

![image](https://user-images.githubusercontent.com/1457604/81132056-05bcdc00-8f45-11ea-8137-ee6b1f3c23ed.png)