### PR TITLE
Adds --module flag for loading es modues directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,12 @@ Servør can be invoked via the command line or programmatically using the node A
 The motivation here was to write a package from the ground up with no dependencies; using only native node and browser APIs to do a specific task with minimal code.
 
 - 🗂 Serves static content like scripts, styles, images from a given directory
-- 🗜 Uses gzip on common filetypes like html, css and js to give a production feel
 - ♻️ Reloads the browser when project files get added, removed or modified
+- 🗜 Uses gzip on common filetypes like html, css, js and json
 - 🔐 Supports https and http2 with trusted self signed certificates
 - 🖥 Redirects all path requests to a single file for frontend routing
-- 🔎 Discovers freely available ports to serve on if no port is specified
+- 📦 Accepts both HTML and JavaScript files as the root file for a directory
+- 🔎 Discovers freely available ports to start on by default
 
 ## CLI Usage
 
@@ -38,7 +39,8 @@ Optional flags passed as non-positional arguments:
 - `--browse` causes the browser to open when the server starts
 - `--reload` causes the browser to reload when files change
 - `--secure` starts the server with https using generated credentials
-- `--silent` prevents the node process from logging to stdout
+- `--silent` prevents the server node process from logging to stdout
+- `--module` causes the server to wrap the root in script type module tags
 
 Example usage with npm scripts in a `package.json` file after running `npm i servor -D`:
 
@@ -55,7 +57,7 @@ Example usage with npm scripts in a `package.json` file after running `npm i ser
 
 ### Generating Credentials
 
-> NOTE: This process depends on the `openssl` command existing (tested on macOS only)
+> NOTE: This process depends on the `openssl` command existing (tested on macOS and linux only)
 
 The files `servor.crt` and `servor.key` need to exist for the server to start using https. If the files do not exist when the `--secure` flag is passed, then [`certify.sh`](/certify.sh) is invoked which:
 
@@ -101,7 +103,7 @@ const { url, root, protocol, port, ips } = await servor(config);
 
 ### Inject
 
-The `inject` property accepts a string that gets prepended to the servers root document (which is `index.html` by default). This could be used to inject config or extend the development servers behavior and capabilities to suit specific environments.
+The `inject` property accepts a string that gets appended to the servers root document (which is `index.html` by default). This could be used to inject config or extend the development servers behavior and capabilities to suit specific environments.
 
 ```js
 const config = require('package.json');

--- a/cli.js
+++ b/cli.js
@@ -51,6 +51,7 @@ const open =
     fallback: args[1],
     port: args[2],
     reload: !!~process.argv.indexOf('--reload'),
+    module: !!~process.argv.indexOf('--module'),
     credentials,
   });
 

--- a/test/assets/index.css
+++ b/test/assets/index.css
@@ -9,7 +9,7 @@
   -webkit-tap-highlight-color: transparent;
 }
 
-body {
+main {
   font-family: 'Roboto', sans-serif;
   font-size: 16px;
   background: #212121;

--- a/test/assets/index.js
+++ b/test/assets/index.js
@@ -1,2 +1,2 @@
 var $text = document.querySelector('h2');
-$text.innerHTML = window.location
+$text.innerHTML = window.location;

--- a/test/index.html
+++ b/test/index.html
@@ -7,8 +7,10 @@
     <script defer src="/assets/index.js"></script>
   </head>
   <body>
-    <img src="/assets/exists.png" alt="File that exists" />
-    <h1>servør</h1>
-    <h2></h2>
+    <main>
+      <img src="/assets/exists.png" alt="File that exists" />
+      <h1>servør</h1>
+      <h2></h2>
+    </main>
   </body>
 </html>

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,53 @@
+import { react, html, css } from 'https://unpkg.com/rplus';
+
+const style = css`
+  font-family: 'Roboto', sans-serif;
+  font-size: 16px;
+  background: #212121;
+  color: #f2f2f2;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+
+  :global(*) {
+    display: block;
+    flex: none;
+    margin: 0;
+    box-sizing: border-box;
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  :global(head),
+  :global(script),
+  :global(style) {
+    display: none;
+  }
+
+  img {
+    width: 30vmin;
+    opacity: 0.38;
+  }
+
+  h1 {
+    font-size: 20vmin;
+  }
+
+  h2 {
+    color: #6f6f6f;
+    font-size: 4vmin;
+    font-weight: normal;
+  }
+`;
+
+react.render(
+  html`
+    <main className=${style}>
+      <img src="/assets/exists.png" alt="File that exists" />
+      <h1>servør</h1>
+      <h2>${location.href}</h2>
+    </main>
+  `,
+  document.body
+);


### PR DESCRIPTION
Currently servor's default behaviour is to redirect non-file requests to `index.html` but a lot of the time when prototyping apps now I find myself creating a html file containing just:

```js
<script src="./index.js" type="module">
```

The file `index.js` usually imports some modules, does some computation and either logs to the console or renders content into the document body. For example:

```js
import { react, html, css } from 'https://unpkg.com/rplus';

const app = () => {
  const [get, set] = react.useState(null);
  react.useEffect(() => {
    set(Math.random())
  }, []);
  return get ? html `<h1>${get}</h1>` : null;
}

console.log('Started the application!');
react.render( html`<${app} />`,  document.body);
```

The changes in this PR makes it so that if the `--module` flag is passed then servor will serve `index.js (with the following transformation) in response to non-file requests.

```js
if (isRoute && module) {
  file = `<!DOCTYPE html><meta charset='utf-8'/><script type='module'>${file}</script>`;
  ext = 'html';
}
```

It wraps the contents of the file in markup and changes the extension to html. This forces the browser to evaluate the module. This will only work with entry points that describe their dependency tree using the es module syntax (no `cjs` or `require`).