### PR TITLE
Use http2 when secure and not reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The motivation here was to write a package from the ground up with no dependenci
 - 🗂 Serves static content like scripts, styles, images from a given directory
 - 🗜 Uses gzip on common filetypes like html, css and js to give a production feel
 - ♻️ Reloads the browser when project files get added, removed or modified
-- 🔐 Supports https with self signed certificates added to the systems trusted store
+- 🔐 Supports https and http2 with trusted self signed certificates
 - 🖥 Redirects all path requests to a single file for frontend routing
 - 🔎 Discovers freely available ports to serve on if no port is specified
 

--- a/servor.js
+++ b/servor.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const url = require('url');
 const path = require('path');
 const http = require('http');
+const http2 = require('http2');
 const https = require('https');
 const os = require('os');
 const net = require('net');
@@ -67,7 +68,9 @@ module.exports = async ({
   const clients = [];
   const protocol = credentials ? 'https' : 'http';
   const server = credentials
-    ? (cb) => https.createServer(credentials, cb)
+    ? reload
+      ? (cb) => https.createServer(credentials, cb)
+      : (cb) => http2.createSecureServer(credentials, cb)
     : (cb) => http.createServer(cb);
 
   const livereload = reload


### PR DESCRIPTION
Currently servor does not try server over http2 for two reasons:

1. http2 only works over https (which is disabled by default)
2. connection type keep open (used for live reload) is not allowed over http2

But I was doing some lighthouse tests the other day and saw this:

![image](https://user-images.githubusercontent.com/1457604/81458691-a9033080-9193-11ea-9aec-0960416de8c2.png)

Presumably when my projects gets to a CDN it will be served over http2 and score 100.. but I wanted to know for sure so I added in this ternary when choosing what type of server to use:

```js
  const server = credentials
    ? reload
      ? (cb) => https.createServer(credentials, cb)
      : (cb) => http2.createSecureServer(credentials, cb)
    : (cb) => http.createServer(cb);
```

Which means that now if you run `servor --secure` then the http2 protocol is used:

![image](https://user-images.githubusercontent.com/1457604/81458810-6726ba00-9194-11ea-8b2c-ff6c8775f0f5.png)

It would be nice if we could get live reloading working over http2 but I haven't found anything that works yet (without getting web sockets involved) and having this option is better than nothing!
