### PR TITLE
Use . as default arg when opening editor

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -46,9 +46,9 @@ const open =
 
   if (~process.argv.indexOf('--editor')) {
     try {
-      require('child_process').execSync(`code ${args[0]}`);
+      require('child_process').execSync(`code ${args[0] || '.'}`);
     } catch (e) {
-      console.log(`\n  ⚠️  Could not open code editor for ${args[0]}`);
+      console.log(`\n  ⚠️  Could not open code editor for ${args[0] || '.'}`);
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "servor",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "A dependency free dev server for single page app development",
   "repository": "lukejacksonn/servor",
   "main": "./servor.js",


### PR DESCRIPTION
Currently if you don't pass a root then it tries to run `code ` when it should try `code .`.