### PR TITLE
Add support for watching a directory other than project root.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Most features are disabled by default but you can customize behaviour by passing
 Run as a terminal command without adding it as a dependency using `npx`:
 
 ```s
-npx servor <root> <fallback> <port>
+npx servor <root> <fallback> <port> <watchRoot>
 ```
 
 > You can pass a GitHub repo as `<root>` using the syntax `gh:<user>/<repository>`
@@ -45,6 +45,7 @@ npx servor <root> <fallback> <port>
 - `<root>` path to serve static files from (defaults to current directory `.`)
 - `<fallback>` the file served for all non-file requests (defaults to `index.html`)
 - `<port>` what port you want to serve the files from (defaults to `8080`)
+- `<watchRoot>` path you want the file watcher to use (defaults to `<root>`)
 
 Optional flags passed as non-positional arguments:
 
@@ -101,6 +102,7 @@ Use servor programmatically with node by requiring it as a module in your script
 const servor = require('servor');
 const instance = await servor({
   root: '.',
+  watchRoot: '.',
   fallback: 'index.html',
   module: false,
   static: false,

--- a/cli.js
+++ b/cli.js
@@ -78,6 +78,7 @@ const open =
     root: args[0],
     fallback: args[1],
     port: args[2],
+    watchRoot: args[3],
     reload: !!~process.argv.indexOf('--reload'),
     module: !!~process.argv.indexOf('--module'),
     static: !!~process.argv.indexOf('--static'),

--- a/servor.js
+++ b/servor.js
@@ -13,6 +13,7 @@ const { fileWatch, usePort, networkIps } = require('./utils/common.js');
 
 module.exports = async ({
   root = '.',
+  watchRoot = root,
   module = false,
   fallback = module ? 'index.js' : 'index.html',
   reload = true,
@@ -36,6 +37,7 @@ module.exports = async ({
   // Configure globals
 
   root = root.startsWith('/') ? root : path.join(process.cwd(), root);
+  watchRoot = watchRoot.startsWith('/') ? watchRoot : path.join(process.cwd(), watchRoot);
 
   const reloadClients = [];
   const protocol = credentials ? 'https' : 'http';
@@ -152,7 +154,7 @@ module.exports = async ({
   // Notify livereload reloadClients on file change
 
   reload &&
-    fileWatch(root, () => {
+    fileWatch(watchRoot, () => {
       while (reloadClients.length > 0)
         sendMessage(reloadClients.pop(), 'message', 'reload');
     });
@@ -165,5 +167,5 @@ module.exports = async ({
   });
 
   const x = { url: `${protocol}://localhost:${port}` };
-  return { ...x, root, protocol, port, ips: networkIps };
+  return { ...x, root, watchRoot, protocol, port, ips: networkIps };
 };


### PR DESCRIPTION
Love using this tiny simple server, thanks. I recently did this for myself and figured I'd share in case anyone happened to be interested.

The usecase is that I'm running a bundler/watcher already that's building my code as I edit, and if I watch both the src root and the bundled root the page refreshes twice for every edit (once for the actual edit, once for the bundle update). This way I can tell servor to only refresh when the bundle  updates but not have to move around my index.html etc.

Maybe too specific to be included so feel free to close this if you think so.