### PR TITLE
Directory listing: wrap links in quotes

### DIFF
--- a/utils/directoryListing.js
+++ b/utils/directoryListing.js
@@ -10,14 +10,14 @@ module.exports = (uri) => {
       ? `
         <div>
           <span>🗂</span>
-          <a href=${`${x}/`}>${x}</a>
+          <a href="${`${x}/`}">${x}</a>
           <small>${size(x)}B</small>
         </div>
       `
       : `
         <div>
           <span>📄</span>
-          <a href=${x}>${x}</a>
+          <a href="${x}">${x}</a>
           <small>${size(x)}B</small>
         </div>
       `;


### PR DESCRIPTION
Currently, files with spaces in their names won't be linked to correctly:

![image](https://user-images.githubusercontent.com/8181990/109431593-afef7e00-7a07-11eb-812a-3124edfdb3da.png)

This PR wraps any links in quotation marks (e. g. `href=test file.txt` becomes `href="test file.txt"`), fixing this problem.