### PR TITLE
Prevent path traversal

### DIFF
--- a/servor.js
+++ b/servor.js
@@ -142,7 +142,8 @@ module.exports = async ({
   // Start the server and route requests
 
   server((req, res) => {
-    const pathname = decodeURI(url.parse(req.url).pathname);
+    const decodePathname = decodeURI(url.parse(req.url).pathname);
+    const pathname = path.normalize(decodePathname).replace(/^(\.\.(\/|\\|$))+/, '');
     res.setHeader('access-control-allow-origin', '*');
     if (reload && pathname === '/livereload') return serveReload(res);
     if (!isRouteRequest(pathname)) return serveStaticFile(res, pathname);


### PR DESCRIPTION
Added measures for path traversal.

If accessing from a browser, `../` will be resolved before sending, but if use curl etc., you can send a request containing the value of `../`.

You can see the contents of the parent directory by launching servor and sending the following request.

```
curl --path-as-is http://localhost:8080/../
```

FYI https://security.stackexchange.com/a/123723